### PR TITLE
Add dependencies to gemspec

### DIFF
--- a/thetvdb.gemspec
+++ b/thetvdb.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'nokogiri'
+  spec.add_dependency 'rest-client'
+
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Thanks for the tutorial :) But when I wanted to test the gem, it didn't install rest-client as a dependency while running bundle install. After specifying dependencies in gemspec it worked.
